### PR TITLE
TH-17 Fix IE8 error

### DIFF
--- a/tasks/uglify.js
+++ b/tasks/uglify.js
@@ -3,7 +3,9 @@ module.exports = function( config ) {
     return {
         dist: {
             options: {
-                mangle: true,
+                mangle: {
+                	screw_ie8: false
+                },
                 preserveComments: /^!/,
                 sourceMap: true,
                 sourceMapName: 'dist/tophat.map',
@@ -15,7 +17,8 @@ module.exports = function( config ) {
                   unused: true,
                   if_return: true,
                   join_vars: true,
-                  drop_console: true
+                  drop_console: true,
+                  screw_ie8: false
                 }
             },
 


### PR DESCRIPTION
https://nicedigital.atlassian.net/browse/TH-17

Caused by Uglify (as of 2.7.0) screwing IE8 by default. We now have to *explicitly* tell uglify to not screw ie8.