### PR TITLE
Add extra command parameter for passing in a custom version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ npm i
 | Task | Description |
 | ---- | ----------- |
 | `npm start` | Default task that builds assets, watches for changes to recompile and serves content on locahost:8000 |
-| `grunt` | Default grunt task that builds assets and watches for changes to recompile |
-| `grunt build` | Builds the distributable scripts form the source files |
-| `grunt webserver` | Starts a dev web server on the first available port starting from 8000 |
-| `grunt test` or `npm test` | Runs jshint against the script and test files then runs the html screenshot tests (via Casper) to check for changes to the designs |
+| `npm run build` | Builds the distributable scripts form the source files |
+| `npm run build -- --buildNumber=X.X.X` | Used for overriding the version set in the banner of the JS file (Useful in TeamCity as our TC build numbers aren't valid npm versions) |
+| `npm test` (or `grunt test`) | Runs jshint against the script and test files then runs the html screenshot tests (via Casper) to check for changes to the designs |
+
+> Note: there are other lower level grunt commands (see Gruntfile.js) but we recommend using the npm scripts where possible.
 
 ## Development
 

--- a/tasks/browserify.js
+++ b/tasks/browserify.js
@@ -5,7 +5,7 @@ var cssify = require('cssify')
 module.exports = {
     options: {
         transform: [ cssify, partialify.onlyAllow(['html']) ],
-        banner: '/*!\n@name <%= pkg.name %>\n@version <%= pkg.version %> | <%= grunt.template.today("yyyy-mm-dd") %>\n*/\n'
+        banner: '/*!\n@name <%= pkg.name %>\n@version <%= grunt.option("buildNumber") || pkg.version %> | <%= grunt.template.today("yyyy-mm-dd") %>\n*/\n'
     },
 
     dist: {


### PR DESCRIPTION
For adding for to the banner at the top of the generated JS.
Used because TeamCity versions are not valid npm versions so can't be set in package.json